### PR TITLE
Print schema with rich formatting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ PyYAML               == 6.0.3
 regex                == 2026.2.28
 requests             == 2.32.5
 requests-toolbelt    == 1.0.0
+rich                 == 15.0.0
 scipy                == 1.17.1
 sniffio              == 1.3.1
 tenacity             == 9.1.4

--- a/workshop-genai/extract_schema.py
+++ b/workshop-genai/extract_schema.py
@@ -4,6 +4,7 @@ load_dotenv()
 
 from neo4j_graphrag.experimental.components.schema import SchemaFromTextExtractor
 from neo4j_graphrag.llm import OpenAILLM
+from rich import print
 import asyncio
 
 schema_extractor = SchemaFromTextExtractor(


### PR DESCRIPTION
This PR makes the schema easier to understand for students.
Instead of a compact block of solid text, the structured output is much easier to read.
The `rich` package provides a `print` function that overrides the default one.

Before:
<img width="1278" height="226" alt="image" src="https://github.com/user-attachments/assets/d5848050-5475-43b8-af18-b0433598f1ac" />

After:
<img width="813" height="973" alt="image" src="https://github.com/user-attachments/assets/97ddd550-4403-46d5-a4c0-19ada6603671" />
