### PR TITLE
make entity label extraction order independent and drop null fields

### DIFF
--- a/workshop-genai/solutions/agent_text2cypher.py
+++ b/workshop-genai/solutions/agent_text2cypher.py
@@ -39,15 +39,13 @@ RETURN
     collect { 
         MATCH (node)<-[:FROM_CHUNK]-(entity)-[r]->(other)-[:FROM_CHUNK]->()
         WITH toStringList([
-            labels(entity)[2], 
+            [l IN labels(entity)
+                WHERE NOT l IN ["__KGBuilder__", "__Entity__"]][0],
             entity.name, 
-            entity.type, 
-            entity.description, 
             type(r), 
-            labels(other)[2], 
-            other.name, 
-            other.type, 
-            other.description
+            [l IN labels(other)
+                WHERE NOT l IN ["__KGBuilder__", "__Entity__"]][0],
+            other.name
             ]) as values
         RETURN reduce(acc = "", item in values | acc || coalesce(item || ' ', ''))
     } as associated_entities
@@ -152,4 +150,4 @@ Each lesson is part of a module. How many lessons are in each module?
 Search the graph and return a list of challenges.
 What benefits are associated to the technologies described in the knowledge graph?
 """
-# end::example_queries[]    
+# end::example_queries[]

--- a/workshop-genai/solutions/agent_vector.py
+++ b/workshop-genai/solutions/agent_vector.py
@@ -37,18 +37,16 @@ MATCH (node)-[:FROM_DOCUMENT]->(d)-[:PDF_OF]->(lesson)
 RETURN
     node.text as text, score,
     lesson.url as lesson_url,
-    collect { 
+    collect {
         MATCH (node)<-[:FROM_CHUNK]-(entity)-[r]->(other)-[:FROM_CHUNK]->()
         WITH toStringList([
-            labels(entity)[2], 
-            entity.name, 
-            entity.type, 
-            entity.description, 
-            type(r), 
-            labels(other)[2], 
-            other.name, 
-            other.type, 
-            other.description
+            [l IN labels(entity)
+                WHERE NOT l IN ["__KGBuilder__", "__Entity__"]][0],
+            entity.name,
+            type(r),
+            [l IN labels(other)
+                WHERE NOT l IN ["__KGBuilder__", "__Entity__"]][0],
+            other.name
             ]) as values
         RETURN reduce(acc = "", item in values | acc || coalesce(item || ' ', ''))
     } as associated_entities

--- a/workshop-genai/solutions/vector_cypher_rag.py
+++ b/workshop-genai/solutions/vector_cypher_rag.py
@@ -45,15 +45,13 @@ RETURN
     collect { 
         MATCH (node)<-[:FROM_CHUNK]-(entity)-[r]->(other)-[:FROM_CHUNK]->()
         WITH toStringList([
-            labels(entity)[2], 
+            [l IN labels(entity)
+                WHERE NOT l IN ["__KGBuilder__", "__Entity__"]][0],
             entity.name, 
-            entity.type, 
-            entity.description, 
             type(r), 
-            labels(other)[2], 
-            other.name, 
-            other.type, 
-            other.description
+            [l IN labels(other)
+                WHERE NOT l IN ["__KGBuilder__", "__Entity__"]][0],
+            other.name 
             ]) as values
         RETURN reduce(acc = "", item in values | acc || coalesce(item || ' ', ''))
     } as associated_entities


### PR DESCRIPTION
Should be merged together with https://github.com/neo4j-graphacademy/courses/pull/569

Previously we assumed that all entities would output labels() in order like `["__KGBuilder__", "__Entity__", "Process"]`, where `[2]` would be the entity label/type we were after. But I've found that ordering is not guaranteed and have witnessed examples like
`["__KGBuilder__", "Technology", "__Entity__"]`. So this commit uses a more robust method, looking for the label that is not `"__KGBuilder__"`, or `"__Entity__"`. We also drop the extraneous `entity.type`, `other.type`, `entity.description`, `other.description` fields that were always `NULL` and would throw warnings during retriever execution.